### PR TITLE
Paper Link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ In our benchmark on the Kuramoto model NetworkDynamics.jl + DifferentialEquation
 
 ## Citations
 
-If you use NetworkDynamics.jl in your research publications, please cite our [paper](https://arxiv.org/abs/2012.12696).
+If you use NetworkDynamics.jl in your research publications, please cite our [paper](https://aip.scitation.org/doi/10.1063/5.0051387).
 
 ```latex
 @article{NetworkDynamics.jl-2021,


### PR DESCRIPTION
The link is still directed to the ArXiv version of the paper.