### PR TITLE
Update of benchmark scripts

### DIFF
--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
 NetworkDynamics = "22e9dc34-2a0d-11e9-0de0-8588d035468b"

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -22,17 +22,4 @@ which will run the benchmark defined in the current directory
 
 and export the results to `target.md`, `baseline.md` and `judgment.md`.
 
-Arguments:
-- `-t, --target`: Specify branch, commit id, tag, ... for target benchmark. If `directory` use the current state of the directory. Default: `directory`
-- `-b, --baseline`: Same for baseline benchmark. Default: `main`. If `none` or `nothing` skip the baseline benckmark and coparison step
-- `--command`: Julia command to use for benchmarks, defaults to `julia`
-- `--tcommand`: Julia command for target, if unset use `--command`
-- `--bcommand`: Julia command for baseline, if unset use `--command`
-- `--threads`: set thread number env variable, defaults to `4`
-- `-v, --verbose`: show the current benchmark during run
-- `-p, --prefix`: prefix for filenames, defaults to timestamp
-- `--retune`: Force [retuning](https://juliaci.github.io/BenchmarkTools.jl/dev/manual/#Caching-Parameters) before the first benchmark (second benchmark will use the tune file).
-- `--exportraw`: export raw data of trials, i.e. to perform your own, additional analysis
-
-See the [`PkgBenchmark.jl` docs](https://juliaci.github.io/PkgBenchmark.jl/stable/) for more details.
-
+See `$./run_benchmarks.jl --help` for list of arguments.

--- a/benchmark/run_benchmarks.jl
+++ b/benchmark/run_benchmarks.jl
@@ -1,5 +1,8 @@
 #!/usr/bin/env julia
 
+# record start time
+tstart = time()
+
 # set root path of the ND repo
 NDPATH = begin
     path = splitpath(abspath(@__DIR__))
@@ -9,43 +12,51 @@ end
 BMPATH = joinpath(NDPATH, "benchmark")
 
 # activate the benchmark folder as current environment
-import Pkg; Pkg.activate(BMPATH); Pkg.develop(path=NDPATH);
+io = IOBuffer() # hide output
+import Pkg; Pkg.activate(BMPATH; io); Pkg.develop(path=NDPATH; io);
 
 using PkgBenchmark
 using LibGit2
 using Dates
 using Random
+using ArgParse
 
-tstart = time()
-
-# rudimentary arg parse function
-function getarg(default, flags...)
-    idx = findfirst(x -> x ∈ flags, ARGS)
-    return idx===nothing ? default : ARGS[idx+1]
+s = ArgParseSettings()
+@add_arg_table! s begin
+    "--target", "-t"
+        help = "Specify branch, commit id, tag, … for target benchmark. If `directory` use the current state of the directory. If *.date file use prev. exporte raw results."
+        default = "directory"
+    "--baseline", "-b"
+        help = "Same for baseline benchmark. If `none` or `nothing` skip the baseline benckmark and coparison step."
+        default = "main"
+    "--command"
+        help = "Julia command for benchmarks"
+        default = "julia"
+    "--tcommand"
+        help = "Julia command for target benchmarks. If nothing use `--command`"
+    "--bcommand"
+        help = "Julia command for baseline benchmarks. If nothing use `--command`"
+    "--threads"
+        help = "Set number of threads."
+        arg_type = Int
+        default = 4
+    "--prefix", "-p"
+        help = "Prefix for filenames, defaults to timestamp"
+        default = Dates.format(now(), "yyyy-mm-dd_HHMMSS")
+    "--verbose", "-v"
+        help = "Print out the current benchmark."
+        action = :store_true
+    "--retune"
+        help = "Force retuneing of parameters befor the first benchmark. (Second benchmark will use the tune file)"
+        action = :store_true
+    "--exportraw"
+        help = "Export raw data of trials. I.e. to use benchmarks results again als baseline or target."
+        action = :store_true
 end
+args = parse_args(s; as_symbols=true)
+args[:prefix] *= '_'
 
-# target defaults to nothing which means the current directory
-target_id   = getarg("directory", "-t", "--target")
-# baseline defaults to "main" branach. if "nothing" or "none" don't run second benchmark
-baseline_id = getarg("main", "-b", "--baseline")
-# number of threads, defaults to 4
-num_threads = parse(Int, getarg("4", "--threads"))
-# chose julia executable (the default one)
-julia_cmd   = getarg("julia", "--command")
-# chose julia executable for target specificially
-julia_cmd_target = getarg("", "--tcommand")
-# chose julia executable for baseline specificially
-julia_cmd_baseline = getarg("", "--bcommand")
-# verbose flag, print current benchmark
-verbose = "-v" ∈ ARGS || "--verbose" ∈ ARGS
-# force retune
-retune = "--retune" ∈ ARGS
-# export raw benchmark data
-exportraw = "--exportraw" ∈ ARGS
-# target defaults to nothing which means the current directory
-prefix = getarg(Dates.format(now(), "yyyy-mm-dd_HHMMSS"), "-p", "--prefix") * "_"
-
-@info "Run benchmarks on $target_id and compare to $baseline_id"
+@info "Run benchmarks on $(args[:target]) and compare to $(args[:baseline])"
 
 #=
 PkgBenchmark will do stuff to the repo (i.e. check out the desired branch),
@@ -107,44 +118,47 @@ end
 directory even if dirty!
 - cmd if empty use default julia command
 """
-function benchmark(; name, id, cmd::AbstractString, retune)
-    # choose specific command only if given
-    cmd = isempty(cmd) ? julia_cmd : cmd
+function benchmark(; name, id, cmd, retune)
+    # choose specific command only if given, elso the default command
+    cmd = isnothing(cmd) ? args[:command] : cmd
     @info "Run $name benchmarks on $id with $cmd"
     # magic id directory will benchmark dirty state
     id = id=="directory" ? nothing : id
     config = BenchmarkConfig(;id,
-                             env = Dict("JULIA_NUM_THREADS" => num_threads),
+                             env = Dict("JULIA_NUM_THREADS" => args[:threads]),
                              juliacmd = string_to_command(cmd))
     results = benchmarkpkg(ndpath_tmp, config;
                            script=script_path,
                            retune,
-                           verbose)
-    exportraw && writeresults(joinpath(BMPATH, prefix*name*".data"), results)
-    export_markdown(joinpath(BMPATH, prefix*name*".md"), results)
+                           verbose=args[:verbose])
+    args[:exportraw] && writeresults(joinpath(BMPATH, args[:prefix]*name*".data"), results)
+    export_markdown(joinpath(BMPATH, args[:prefix]*name*".md"), results)
     return results
 end
 
-target = benchmark(; name="target", id=target_id, cmd=julia_cmd_target, retune)
+if contains(args[:target], r".data$")
+    path = joinpath(BMPATH, args[:target])
+    target = readresults(joinpath(BMPATH, args[:target]))
+else
+    target = benchmark(; name="target", id=args[:target], cmd=args[:tcommand], retune=args[:retune])
+end
 
-if contains(baseline_id, r".data$")
-    path = joinpath(BMPATH, baseline_id)
-    baseline = readresults(joinpath(BMPATH, baseline_id))
-
-    judgment = judge(target, baseline)
-    export_markdown(joinpath(BMPATH, prefix*"judgment.md"), judgment)
-elseif baseline_id ∉ ["nothing", "none"]
-    baseline = benchmark(; name="baseline", id=baseline_id, cmd=julia_cmd_baseline, retune=false)
-
+if args[:baseline] ∉ ["nothing", "none"]
+    if contains(args[:baseline], r".data$")
+        path = joinpath(BMPATH, args[:baseline])
+        baseline = readresults(joinpath(BMPATH, args[:baseline]))
+    elseif args[:baseline] ∉ ["nothing", "none"]
+        baseline = benchmark(; name="baseline", id=args[:baseline], cmd=args[:bcommand], retune=false)
+    end
     # compare the two
     judgment = judge(target, baseline)
-    export_markdown(joinpath(BMPATH, prefix*"judgment.md"), judgment)
+    export_markdown(joinpath(BMPATH, args[:prefix]*"judgment.md"), judgment)
 end
 
 # copy tune file over to real repo if there is none yet or it was retuned
-if !isfile(joinpath(BMPATH, "tune.json")) || retune
+if !isfile(joinpath(BMPATH, "tune.json")) || args[:retune]
     println("Update tune.json in $BMPATH")
-    cp(joinpath(ndpath_tmp, "benchmark", "tune.json"), joinpath(BMPATH, "tune.json"); force=retune)
+    cp(joinpath(ndpath_tmp, "benchmark", "tune.json"), joinpath(BMPATH, "tune.json"); force=args[:retune])
 end
 
 s = round(Int, time()-tstart)

--- a/benchmark/run_benchmarks.jl
+++ b/benchmark/run_benchmarks.jl
@@ -14,6 +14,7 @@ import Pkg; Pkg.activate(BMPATH); Pkg.develop(path=NDPATH);
 using PkgBenchmark
 using LibGit2
 using Dates
+using Random
 
 tstart = time()
 
@@ -69,6 +70,7 @@ isdirty = with(LibGit2.isdirty, GitRepo(ndpath_tmp))
 if isdirty
     @info "Dirty directory, add everything to new commit!"
     @assert realpath(pwd()) == realpath(ndpath_tmp) "Julia is in $(pwd()) not it $ndpath_tmp"
+    run(`git checkout -b $(randstring(15))`)
     run(`git add -A`)
     run(`git commit -m "tmp commit for benchmarking"`)
     # assert that repo is clean now

--- a/benchmark/run_benchmarks.jl
+++ b/benchmark/run_benchmarks.jl
@@ -127,7 +127,13 @@ end
 
 target = benchmark(; name="target", id=target_id, cmd=julia_cmd_target, retune)
 
-if baseline_id ∉ ["nothing", "none"]
+if contains(baseline_id, r".data$")
+    path = joinpath(BMPATH, baseline_id)
+    baseline = readresults(joinpath(BMPATH, baseline_id))
+
+    judgment = judge(target, baseline)
+    export_markdown(joinpath(BMPATH, prefix*"judgment.md"), judgment)
+elseif baseline_id ∉ ["nothing", "none"]
     baseline = benchmark(; name="baseline", id=baseline_id, cmd=julia_cmd_baseline, retune=false)
 
     # compare the two


### PR DESCRIPTION
I've switched from my hacky arg parser to [ArgParse.jl](https://github.com/carlobaldassi/ArgParse.jl). This is just a benchmark dep so it shouldn't matter. But there are nice side effects like `./run_benchmarks.jl --help` is helpful now.

<details>
  <summary>Click to expand help string</summary>

```
$> ./run_benchmarks.jl --help
usage: run_benchmarks.jl [-t TARGET] [-b BASELINE] [--command COMMAND]
                        [--tcommand TCOMMAND] [--bcommand BCOMMAND]
                        [--threads THREADS] [-p PREFIX] [-v]
                        [--retune] [--exportraw] [-h]

optional arguments:
  -t, --target TARGET   Specify branch, commit id, tag, … for target
                        benchmark. If `directory` use the current
                        state of the directory. If *.date file use
                        prev. exporte raw results. (default:
                        "directory")
  -b, --baseline BASELINE
                        Same for baseline benchmark. If `none` or
                        `nothing` skip the baseline benckmark and
                        coparison step. (default: "main")
  --command COMMAND     Julia command for benchmarks (default:
                        "julia")
  --tcommand TCOMMAND   Julia command for target benchmarks. If
                        nothing use `--command`
  --bcommand BCOMMAND   Julia command for baseline benchmarks. If
                        nothing use `--command`
  --threads THREADS     Set number of threads. (type: Int64, default:
                        4)
  -p, --prefix PREFIX   Prefix for filenames, defaults to timestamp
                        (default: "2021-08-11_162609")
  -v, --verbose         Print out the current benchmark.
  --retune              Force retuneing of parameters befor the first
                        benchmark. (Second benchmark will use the tune
                        file)
  --exportraw           Export raw data of trials. I.e. to use
                        benchmarks results again als baseline or
                        target.
  -h, --help            show this help message and exit
```

</details>


Besides that i've added the option to use data exported with `--exportraw` as target or baseline. I.e.
```
$> ./run_benchmarks.jl -t main -b nothing --prefix "main" --exportraw
```
will create the files `main_target.data` and `main_target.md`.

Now it is possible to call
```
$> ./run_benchmarks.jl -b main_target.data
```
to benchmark `directory` (the default target) and compare to `main_target.data` without redoing the benchmark. This will export a new `_target.md` and `_judgement.md` file.

It is also possible to compare to `*.data` files by passing them as target and baseline.