### PR TITLE
simplify methods of network_dynamics

### DIFF
--- a/src/NetworkDynamics.jl
+++ b/src/NetworkDynamics.jl
@@ -44,8 +44,8 @@ function collect_ve_info(vertices!, edges!, graph)
         symbols_e = [Symbol(edges![i].sym[j], "_", i)
                      for i in 1:length(edges!)
                      for j in 1:e_dims[i]]
-        hasODEEdge = any(e -> e isa ODEEdge, edges!) #those are the only ones with MM atm
-        if hasODEEdge # at the moment 1 ODEEdge should imply all e are ODEEdge
+        hasMM = any(e -> hasproperty(e, :mass_matrix), edges!) # ODEEdges are the only ones with MM atm
+        if hasMM # 1 ODEEdge should imply all e are ODEEdge
             mme_array = [e.mass_matrix for e in edges!]
         else
             mme_array = nothing
@@ -55,7 +55,7 @@ function collect_ve_info(vertices!, edges!, graph)
         symbols_e = [Symbol(edges!.sym[j], "_", i)
                      for i in 1:ne(graph)
                      for j in 1:e_dims[i]]
-        if typeof(edges!)<:ODEEdge
+        if hasproperty(edges!, :mass_matrix)
             mme_array = [edges!.mass_matrix for e in edges(graph)]
         else
             mme_array = nothing

--- a/src/NetworkDynamics.jl
+++ b/src/NetworkDynamics.jl
@@ -44,20 +44,20 @@ function collect_ve_info(vertices!, edges!, graph)
         symbols_e = [Symbol(edges![i].sym[j], "_", i)
                      for i in 1:length(edges!)
                      for j in 1:e_dims[i]]
-        if eltype(edges!) <: Union{StaticEdge,StaticDelayEdge}  # improve type hierarchy
-            mme_array = nothing
-        else
+        if eltype(edges!)<:ODEEdge #at the moment 1 ODEEdge should imply all e are ODEEdge
             mme_array = [e.mass_matrix for e in edges!]
+        else
+            mme_array = nothing
         end
     else
         e_dims = [edges!.dim for e in edges(graph)]
         symbols_e = [Symbol(edges!.sym[j], "_", i)
                      for i in 1:ne(graph)
                      for j in 1:e_dims[i]]
-        if typeof(edges!) <: Union{StaticEdge,StaticDelayEdge} # improve type hierarchy
-            mme_array = nothing
-        else
+        if typeof(edges!)<:ODEEdge
             mme_array = [edges!.mass_matrix for e in edges(graph)]
+        else
+            mme_array = nothing
         end
     end
 
@@ -226,7 +226,7 @@ function prepare_edges(edge::EdgeFunction, g::SimpleGraph)
     if edge.coupling == :directed
         throw(ArgumentError("Coupling type of EdgeFunction not available for undirected Graphs"))
     elseif edge.coupling == :undefined
-        @info("Reconstructing EdgeFunction with :undefined coupling type...")
+        @info("Reconstructing EdgeFunction with :undefined coupling type..")
         return reconstruct_edge(edge, :undirected)
     end
     return edge
@@ -236,7 +236,7 @@ function prepare_edges(edge::EdgeFunction, g::SimpleDiGraph)
     if edge.coupling ∈ (:symmetric, :antisymmetric, :undirected, :fiducial)
         throw(ArgumentError("Coupling type of EdgeFunction not available for directed Graphs"))
     elseif edge.coupling == :undefined
-        @info("Reconstructing EdgeFunction with :undefined coupling type...")
+        @info("Reconstructing EdgeFunction with :undefined coupling type..")
         return reconstruct_edge(edge, :directed)
     end
     return edge
@@ -254,7 +254,7 @@ function prepare_edges(edges::Vector, g::SimpleGraph)
             throw(ArgumentError("Coupling type of edge $i not available for undirected Graphs"))
         elseif edge.coupling == :undefined
             if infobool
-                @info("Reconstructing EdgeFuntions with :undefined coupling type.")
+                @info("Reconstructing EdgeFuntions with :undefined coupling to have :undirected coupling. For optimal performance specify the coupling type during initialization of the edge function.")
                 infobool = false
             end
             new_edges[i] = reconstruct_edge(edge, :undirected)
@@ -278,7 +278,7 @@ function prepare_edges(edges::Vector, g::SimpleDiGraph)
             throw(ArgumentError("Coupling type of edge $i not available for directed Graphs"))
         elseif edge.coupling == :undefined
             if infobool
-                @info("Reconstructing EdgeFuntions with :undefined coupling type.")
+                @info("Reconstructing EdgeFuntions with :undefined coupling type..")
                 infobool = false
             end
             new_edges[i] = reconstruct_edge(edge, :directed)

--- a/src/NetworkDynamics.jl
+++ b/src/NetworkDynamics.jl
@@ -105,6 +105,10 @@ function network_dynamics(vertices!::Union{T,Vector{T}},
                           kwargs...) where {T,U}
     if vertices! isa Vector
         @assert length(vertices!) == nv(graph)
+        if length(vertices!) == 0
+            # empty graph
+            vertices! == VertexFunction[]
+        end
         if !(eltype(vertices!)<:VertexFunction)
             # narrow type
             vertices! = [v for v in vertices!]
@@ -116,9 +120,13 @@ function network_dynamics(vertices!::Union{T,Vector{T}},
 
     if edges! isa Vector
         @assert length(edges!) == ne(graph)
+        if length(edges!) == 0
+            # graph without lines
+            edges! == EdgeFunction[]
+        end
         if !(eltype(edges!)<:EdgeFunction)
             # narrow type
-            edges! = [v for v in edges!]
+            edges! = [e for e in edges!]
         end
         hasDelayEdge = any(e -> e isa StaticDelayEdge, edges!)
         hasODEEdge = any(e -> e isa ODEEdge, edges!)
@@ -135,7 +143,7 @@ function network_dynamics(vertices!::Union{T,Vector{T}},
 
     # If one edge is an ODEEdge all other edges will be promoted. Eventually we will get rid of promotions.
     if hasODEEdge && hasStaticEdge
-        edges! = Array{ODEEdge}(edges!)
+        edges! = Vector{ODEEdge}(edges!)
     end
 
     return _network_dynamics(vertices!, edges!, graph; kwargs...)

--- a/src/NetworkDynamics.jl
+++ b/src/NetworkDynamics.jl
@@ -107,7 +107,7 @@ function network_dynamics(vertices!::Union{T,Vector{T}},
         @assert length(vertices!) == nv(graph)
         if length(vertices!) == 0
             # empty graph
-            vertices! == VertexFunction[]
+            vertices! = VertexFunction[]
         end
         if !(eltype(vertices!)<:VertexFunction)
             # narrow type
@@ -122,7 +122,7 @@ function network_dynamics(vertices!::Union{T,Vector{T}},
         @assert length(edges!) == ne(graph)
         if length(edges!) == 0
             # graph without lines
-            edges! == EdgeFunction[]
+            edges! = EdgeFunction[]
         end
         if !(eltype(edges!)<:EdgeFunction)
             # narrow type

--- a/test/ComponentFunctions_test.jl
+++ b/test/ComponentFunctions_test.jl
@@ -1,9 +1,51 @@
 using Test
 using Graphs
 using NetworkDynamics
-using OrdinaryDiffEq
-using DelayDiffEq
-using LinearAlgebra
+# using OrdinaryDiffEq
+# using DelayDiffEq
+# using LinearAlgebra
+
+@testset "Unique edges" begin
+    N=3
+    g=complete_graph(N)
+
+    f = (e, v_s, v_d, p, t) -> begin
+        e .= v_s .- v_d
+        nothing
+    end
+
+    v = (dv,v,edges,p,t) -> begin
+        for e in edges
+            dv .+= e
+        end
+    end
+
+    eundir = StaticEdge(; f=f, dim=2, coupling = :undirected)
+    eundef = StaticEdge(; f=f, dim=2)
+    deundef = StaticDelayEdge(;f=f, dim=2)
+
+    mixed_edges = [eundef, eundef, deundef]
+
+    vertex = ODEVertex(; f=v, dim=1)
+
+    ndundir = network_dynamics(vertex,eundir, g)
+    @test length(ndundir.f.unique_edges!) == 1
+
+    ndundef = network_dynamics(vertex,eundef, g)
+    @test length(ndundef.f.unique_edges!) == 1
+
+    nddirundef = network_dynamics(vertex,eundef, SimpleDiGraph(g))
+    @test length(nddirundef.f.unique_edges!) == 1
+
+    # The wrapper created for :undefined -> :undirected reconstruction interfers with
+    # uniqueness of edge functions
+    ndmix = network_dynamics(vertex, mixed_edges, g)
+    @test_broken length(ndmix.f.unique_edges!) == 2
+
+    nddirmix = network_dynamics(vertex, repeat(mixed_edges,2), SimpleDiGraph(g))
+    @test length(nddirmix.f.unique_edges!) == 2
+end
+
 
 @testset "StaticEdge constructor" begin
     f = (e, v_s, v_d, p, t) -> begin

--- a/test/ComponentFunctions_test.jl
+++ b/test/ComponentFunctions_test.jl
@@ -1,9 +1,9 @@
 using Test
 using Graphs
 using NetworkDynamics
-# using OrdinaryDiffEq
-# using DelayDiffEq
-# using LinearAlgebra
+using OrdinaryDiffEq
+using DelayDiffEq
+using LinearAlgebra
 
 @testset "Unique edges" begin
     N=3


### PR DESCRIPTION
works around #102 by avoiding the copying of a single Vertex Function, however the reconstruction of two copies with `:undefined -> : undirected` still produces non-identical objects